### PR TITLE
2016-09 big sync from bitbucket

### DIFF
--- a/files/iptables
+++ b/files/iptables
@@ -1,0 +1,13 @@
+# sample configuration for iptables service
+# you can edit this manually or use system-config-firewall
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -p icmp -j ACCEPT
+-A INPUT -i lo -j ACCEPT
+-A INPUT -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT
+-A INPUT -j REJECT --reject-with icmp-host-prohibited
+-A FORWARD -j REJECT --reject-with icmp-host-prohibited
+COMMIT

--- a/files/rsyslog_netfilter.conf
+++ b/files/rsyslog_netfilter.conf
@@ -1,0 +1,2 @@
+:msg,contains,"[netfilter] " /var/log/netfilter
+&~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,21 @@
-# Class: system
+#
+# = Class: system
+#
 class system {
-  group { 'wheel':
-    ensure => present,
-  }
+
+  # load hosts, sysctl, sysfs, limits settings
+  create_resources(host,       hiera_hash('hosts', {}))
+  create_resources('::sysfs',  hiera_hash('sysfs', {}))
+  create_resources('::sysctl', hiera_hash('sysctl',{}))
+  create_resources('::limits', hiera_hash('limits',{}))
+  create_resources('::selinux::module', hiera_hash('selinux::modules',{}))
+  create_resources('::rsyslog::remote', hiera_hash('rsyslog::remotes',{}))
+
+  # selinux settings
+  create_resources('selboolean', hiera_hash('selinux::selbooleans',{}))
+  create_resources('selmodule',  hiera_hash('selinux::selmodules', {}))
+
+  # wheel group container
+  group { 'wheel': ensure => present }
+
 }

--- a/manifests/iptables.pp
+++ b/manifests/iptables.pp
@@ -1,0 +1,42 @@
+#
+# = Class: system::iptables
+#
+class system::iptables (
+  $source = 'puppet:///system/iptables',
+  ){
+
+  include ::rsyslog
+
+  case $::operatingsystemrelease {
+    default: {}
+    /^6.*/: {
+      file { '/etc/rsyslog.d/netfilter.conf':
+        ensure => file,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0644',
+        source => 'puppet:///modules/system/rsyslog_netfilter.conf',
+        notify => Service['rsyslog'],
+      }
+    }
+    /^7.*/: {
+      package { 'firewalld': ensure => absent }
+      package { 'iptables-services': ensure => installed }
+    }
+  }
+
+  file { '/etc/sysconfig/iptables':
+    ensure => file,
+    owner  => root,
+    group  => root,
+    mode   => '0600',
+    source => $source,
+  }
+
+  service { 'iptables':
+    ensure    => running,
+    enable    => true,
+    subscribe => File['/etc/sysconfig/iptables'],
+  }
+
+}

--- a/manifests/restart.pp
+++ b/manifests/restart.pp
@@ -1,0 +1,19 @@
+#
+# = Define: system::restart
+#
+# Sets hourly/daily/weekly/monthly restart of a service
+define system::restart (
+  $template = 'system/restart_service.erb',
+  $schedule = 'daily',
+  $reason   = 'lower memory footprint',
+  ){
+
+  file { "/etc/cron.${schedule}/restart_${name}":
+    ensure  => file,
+    owner   => root,
+    group   => root,
+    mode    => '0755',
+    content => template($template),
+  }
+
+}

--- a/manifests/rootkeys.pp
+++ b/manifests/rootkeys.pp
@@ -1,0 +1,38 @@
+#
+# = Class: system::rootkeys
+#
+# Deploys ssh private and public key for root user from hosts private section.
+#
+# == Requires
+# 'private' section set in auth.conf on master. Definition should look something
+# like this:
+#
+#    [private]
+#     path /etc/puppet/private/%H
+#     allow *
+#
+class system::rootkeys(
+  $source = 'puppet:///private/rootkeys'
+) {
+  File {
+    ensure => file,
+    owner  => root,
+    group  => root,
+  }
+
+  if ! defined(File['/root/.ssh']) {
+    file { '/root/.ssh':
+      ensure => directory,
+      mode   => '0700',
+    }
+  }
+  file { '/root/.ssh/id_rsa':
+    mode   => '0600',
+    source => "${source}/id_rsa",
+  }
+  file { '/root/.ssh/id_rsa.pub':
+    mode   => '0644',
+    source => "${source}/id_rsa.pub",
+  }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,38 @@
+{
+  "name": "lutak-system",
+  "version": "1.0.0",
+  "author": "lutak",
+  "summary": "Manages operating system tunables.",
+  "license": "Apache-2.0",
+  "source": "https://github.com/lutak-srce/system",
+  "project_page": "https://github.com/lutak-srce/system"
+  "dependencies": [],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": "3.x"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ]
+}

--- a/templates/restart_service.erb
+++ b/templates/restart_service.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Restart service '<%= @name %>' on <%= @schedule %> basis to:
+#  <%= @reason %>
+/sbin/service <%= @name %> restart
+
+exit 0
+# EOF


### PR DESCRIPTION
`include ::system` will continue to behave as-is, if you don't have any of the types defined in hiera. If you do have them, and have create resources in other classes, then this could cause double definition of resources.
